### PR TITLE
Fix routing for auth page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
-import Index from "./pages/Index";
+import HomePage from "./components/HomePage";
+import AuthPage from "./components/AuthPage";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -53,7 +54,8 @@ const App = () => (
         <Sonner />
         <BrowserRouter>
           <Routes>
-            <Route path="/" element={<Index />} />
+            <Route path="/" element={<HomePage />} />
+            <Route path="/auth" element={<AuthPage />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { 
   Container, 
   Typography, 
@@ -66,11 +67,8 @@ const characters: Character[] = [
   }
 ];
 
-interface HomePageProps {
-  onNavigateToAuth: () => void;
-}
-
-const HomePage: React.FC<HomePageProps> = ({ onNavigateToAuth }) => {
+const HomePage: React.FC = () => {
+  const navigate = useNavigate();
   const [userFolders] = useState<UserFolder[]>([]);
 
   const TechSphere = () => {
@@ -155,7 +153,7 @@ const HomePage: React.FC<HomePageProps> = ({ onNavigateToAuth }) => {
         <Button
           variant="outlined"
           startIcon={<LoginIcon />}
-          onClick={onNavigateToAuth}
+          onClick={() => navigate('/auth')}
           sx={{
             borderColor: 'hsl(var(--border))',
             color: 'hsl(var(--foreground))',

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -1,29 +1,8 @@
 
-import React, { useState } from 'react';
 import HomePage from '@/components/HomePage';
-import AuthPage from '@/components/AuthPage';
 
 const Index = () => {
-  const [currentView, setCurrentView] = useState<'home' | 'auth'>('home');
-
-  const handleNavigateToAuth = () => {
-    setCurrentView('auth');
-  };
-
-  const handleNavigateToHome = () => {
-    setCurrentView('home');
-  };
-
-  return (
-    <>
-      {currentView === 'home' && (
-        <HomePage onNavigateToAuth={handleNavigateToAuth} />
-      )}
-      {currentView === 'auth' && (
-        <AuthPage onBack={handleNavigateToHome} />
-      )}
-    </>
-  );
+  return <HomePage />;
 };
 
 export default Index;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- setup React Router routes for home and auth pages
- update HomePage button to navigate to `/auth`
- simplify Index page
- fix lint issues in UI components
- switch Tailwind plugin import to ES module

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f49d65ad083329814522d47a938ff